### PR TITLE
Replace `Readdir(-1)` with `os.ReadDir`

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -216,19 +216,14 @@ func ListAddresses(ctx *cli.Context) error {
 		return errors.New("keystore directory doesn't exist")
 	}
 
-	f, err := os.Open(conf.Global.KeystoreDir)
-	if err != nil {
-		return fmt.Errorf("failed to read keystore directory: %w", err)
-	}
-	fileInfo, err := f.Readdir(-1)
-	f.Close()
+	dirEntries, err := os.ReadDir(conf.Global.KeystoreDir)
 	if err != nil {
 		return fmt.Errorf("failed to read keystore directory: %w", err)
 	}
 
-	for i, file := range fileInfo {
-		if file.Name() == "node_identity.json" {
-			fileData, err := os.ReadFile(filepath.Join(conf.Global.KeystoreDir, file.Name()))
+	for i, entry := range dirEntries {
+		if entry.Name() == "node_identity.json" {
+			fileData, err := os.ReadFile(filepath.Join(conf.Global.KeystoreDir, entry.Name()))
 			if err != nil {
 				continue
 			}
@@ -238,7 +233,7 @@ func ListAddresses(ctx *cli.Context) error {
 			continue
 		}
 
-		addrr := hexutil.ExtractHex(file.Name())
+		addrr := hexutil.ExtractHex(entry.Name())
 		if addrr == "" {
 			continue
 		}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -115,21 +115,16 @@ func (ks *Store) UnlockKey(address string, passphrase string) (string, error) {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
 
-	f, err := os.Open(ks.keysDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to read keystore directory: %w", err)
-	}
-	fileInfo, err := f.Readdir(-1)
-	f.Close()
+	dirEntries, err := os.ReadDir(ks.keysDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to read keystore directory: %w", err)
 	}
 
-	for _, file := range fileInfo {
+	for _, entry := range dirEntries {
 		nodeIDKey := false
-		if file.Name() == "node_identity.json" {
+		if entry.Name() == "node_identity.json" {
 			nodeIDKey = true
-			fileData, err := os.ReadFile(filepath.Join(ks.keysDir, file.Name()))
+			fileData, err := os.ReadFile(filepath.Join(ks.keysDir, entry.Name()))
 			if err != nil {
 				continue
 			}
@@ -140,13 +135,13 @@ func (ks *Store) UnlockKey(address string, passphrase string) (string, error) {
 			}
 		} else {
 			nodeIDKey = false
-			fileNameContainsAddress := strings.Contains(file.Name(), address)
+			fileNameContainsAddress := strings.Contains(entry.Name(), address)
 			if !fileNameContainsAddress {
 				continue
 			}
 		}
 
-		bts, err := os.ReadFile(filepath.Join(ks.keysDir, file.Name()))
+		bts, err := os.ReadFile(filepath.Join(ks.keysDir, entry.Name()))
 		if err != nil {
 			return "", fmt.Errorf("failed to read keystore file: %w", err)
 		}
@@ -182,18 +177,13 @@ func (ks *Store) UnlockKey(address string, passphrase string) (string, error) {
 func (ks *Store) ListKeys() ([]string, error) {
 	addresses := make([]string, 0)
 
-	f, err := os.Open(ks.keysDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read keystore directory: %w", err)
-	}
-	fileInfo, err := f.Readdir(-1)
-	f.Close()
+	dirEntries, err := os.ReadDir(ks.keysDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read keystore directory: %w", err)
 	}
 
-	for _, file := range fileInfo {
-		fileData, err := os.ReadFile(filepath.Join(ks.keysDir, file.Name()))
+	for _, entry := range dirEntries {
+		fileData, err := os.ReadFile(filepath.Join(ks.keysDir, entry.Name()))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
We can simplify the following code

```go
dir, err := os.Open(dirname)
if err != nil {
	return err
}
defer dir.Close()

dirs, err := dir.Readdir(-1)
```

with just `os.ReadDir(dirname)`. `os.ReadDir` is recommended over `Readdir()`, as stated in the official doc [^1]

[^1]: "Most clients are better served by the more efficient ReadDir method." https://pkg.go.dev/os#File.Readdir