### PR TITLE
Fixes Fix data query purging #184

### DIFF
--- a/node/protocols/data_query/data_query.go
+++ b/node/protocols/data_query/data_query.go
@@ -80,6 +80,8 @@ func (d *Protocol) PutQueryHistory(key string, val messages.DataQueryRequest) er
 		return fmt.Errorf("failed to insert data query request: %w", err)
 	}
 
+	val.Timestamp = time.Now().Unix()
+
 	d.queryHistoryMux.Lock()
 	defer d.queryHistoryMux.Unlock()
 	d.queryHistory[key] = val

--- a/node/protocols/data_query/data_query_test.go
+++ b/node/protocols/data_query/data_query_test.go
@@ -101,7 +101,7 @@ func TestDataQueryProtocol(t *testing.T) {
 	assert.NoError(t, err)
 	req, ok := protocol2.GetQueryHistory(hexutil.Encode(hashOfOldReq))
 	assert.Equal(t, true, ok)
-	req.Timestamp = req.Timestamp - ((dataQueryReqAgeToPurgeInMins + 1) * 60)
+	req.Timestamp -= ((dataQueryReqAgeToPurgeInMins + 1) * 60)
 	err = protocol2.PurgeQueryHistory()
 	assert.NoError(t, err)
 	assert.Len(t, protocol2.queryHistory, 1)

--- a/node/protocols/data_query/data_query_test.go
+++ b/node/protocols/data_query/data_query_test.go
@@ -92,13 +92,16 @@ func TestDataQueryProtocol(t *testing.T) {
 	dqrequestold := messages.DataQueryRequest{
 		FileHashes:   [][]byte{{12}},
 		FromPeerAddr: h1.ID().String(),
-		Timestamp:    time.Now().Unix() - ((dataQueryReqAgeToPurgeInMins + 1) * 60),
+		Timestamp:    time.Now().Unix(),
 	}
 	hashOfOldReq := dqrequestold.GetHash()
 	dqrequestold.Hash = make([]byte, len(hashOfOldReq))
 	copy(dqrequestold.Hash, hashOfOldReq)
 	err = protocol2.PutQueryHistory(hexutil.Encode(hashOfOldReq), dqrequestold)
 	assert.NoError(t, err)
+	req, ok := protocol2.GetQueryHistory(hexutil.Encode(hashOfOldReq))
+	assert.Equal(t, true, ok)
+	req.Timestamp = req.Timestamp - ((dataQueryReqAgeToPurgeInMins + 1) * 60)
 	err = protocol2.PurgeQueryHistory()
 	assert.NoError(t, err)
 	assert.Len(t, protocol2.queryHistory, 1)


### PR DESCRIPTION
Closes #184 

Updated PutQueryHistory() (in node/protocols/data_query/data_query.go) to update timestamp
Updated test cases for PurgeQueryHistory() to ensure it passes with above changes