### PR TITLE
Improve peer discovery

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -495,7 +495,11 @@ func (n *Node) processIncomingMessage(ctx context.Context, message *pubsub.Messa
 			return fmt.Errorf("failed to decode storage querier peer id: %w", err)
 		}
 
-		_ = n.FindPeers(ctx, []peer.ID{storageQuerier})
+		querierAddr := n.host.Peerstore().Addrs(storageQuerier)
+		if len(querierAddr) == 0 {
+			_ = n.FindPeers(ctx, []peer.ID{storageQuerier})
+		}
+
 		err = n.storageProtocol.SendStorageQueryResponse(ctx, storageQuerier, &response)
 		if err != nil {
 			log.Warnf("failed to send data query response back to initiator: %v", err)

--- a/rpc/storage_test.go
+++ b/rpc/storage_test.go
@@ -15,7 +15,7 @@ func TestNewStorageAPI(t *testing.T) {
 	h := newHost(t, "6691")
 	cases := map[string]struct {
 		host            host.Host
-		publisher       NetworkMessagePublisher
+		publisher       PublisherNodesFinder
 		storageProtocol storageprotocol.Interface
 		storageEngine   storage.Interface
 		expErr          string


### PR DESCRIPTION
With this PR each time a communication is created to a node, it tries to find peer addr locally and if not found we trigger the peer finder