### PR TITLE
Not allowing any dot in filehash name

### DIFF
--- a/cmd/filefilego/main.go
+++ b/cmd/filefilego/main.go
@@ -640,6 +640,11 @@ func serveMediaFile(dataDir, cacheDir string) http.Handler {
 		}
 
 		hash := r.URL.Query().Get("hash")
+		if strings.Contains(hash, ".") {
+			http.NotFound(w, r)
+			return
+		}
+
 		imgType := r.URL.Query().Get("type")
 		filePath := filepath.Join(dataDir, cacheDir, hash)
 		if !common.FileExists(filePath) {


### PR DESCRIPTION
Fixes a security issue with handling filepaths which could contain "."