### PR TITLE
Don't allow directory seperator

### DIFF
--- a/cmd/filefilego/main.go
+++ b/cmd/filefilego/main.go
@@ -627,7 +627,7 @@ func serveMediaFile(dataDir, cacheDir string) http.Handler {
 		}
 
 		hash := r.URL.Query().Get("hash")
-		if strings.Contains(hash, ".") {
+		if strings.ContainsAny(hash, "./\\") {
 			http.NotFound(w, r)
 			return
 		}


### PR DESCRIPTION
A quick fix to disallow directory seperators in hashes